### PR TITLE
keep z-axis motor powered

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,6 @@ MOVEMENT_MIN_SPD_Z           |63
 MOVEMENT_MAX_SPD_X           |71
 MOVEMENT_MAX_SPD_Y           |72
 MOVEMENT_MAX_SPD_Z           |73
-MOVEMENT_MAX_SPD_X           |71
-MOVEMENT_MAX_SPD_Y           |72
-MOVEMENT_MAX_SPD_Z           |73
 ENCODER_ENABLED_X            |101
 ENCODER_ENABLED_Y            |102
 ENCODER_ENABLED_Z            |103

--- a/src/StepperControl.cpp
+++ b/src/StepperControl.cpp
@@ -1020,7 +1020,7 @@ void StepperControl::disableMotors() {
 
   axisX.disableMotor();
 	axisY.disableMotor();
-	axisZ.disableMotor();
+	//axisZ.disableMotor();
 	delay(100);
 }
 


### PR DESCRIPTION
temporary fix for restricting undesired movement of the z-axis until a parameter for this feature can be added